### PR TITLE
Trigger a database_change event when called script returns a specific exit code

### DIFF
--- a/beetsplug/alias.py
+++ b/beetsplug/alias.py
@@ -37,6 +37,9 @@ else:
     import collections as abc
 
 
+EXIT_STATUS_DATABASE_CHANGED = 8
+
+
 class NoOpOptionParser(optparse.OptionParser):
     def parse_args(self, args=None, namespace=None):
         if args is None:
@@ -126,6 +129,15 @@ class AliasCommand(Subcommand):
         plugins.send('alias_succeeded', lib=lib, alias=self.alias, command=command, args=args)
 
     def failed(self, lib, alias, command, args, exitcode=None, message=""):
+        if exitcode == EXIT_STATUS_DATABASE_CHANGED:
+            if self.log:
+                self.log.debug(u'command `{0}` exited with {1}, triggering database change event',
+                               command, exitcode)
+            plugins.send('database_change', lib=lib, model=None)
+        else:
+            if self.log:
+                self.log.debug(u'command `{0}` failed with {1}', command, exitcode)
+
         plugins.send(
             "alias_failed",
             lib=lib,

--- a/beetsplug/alias.py
+++ b/beetsplug/alias.py
@@ -193,7 +193,7 @@ class AliasPlugin(BeetsPlugin):
         for path, subview in [('alias.aliases', self.config['aliases']), ('aliases', config['aliases'])]:
             for alias in subview.keys():
                 if alias in commands:
-                    raise confuse.ConfigError(u'alias {1} was specified multiple times'.format(alias))
+                    raise confuse.ConfigError(u'alias {0} was specified multiple times'.format(alias))
 
                 command = subview[alias].get()
                 if isinstance(command, six.text_type):


### PR DESCRIPTION
This is just a quick and dirty way of doing what I described in the title, but it's more of a conversation starter. My specific use case (but I think it could be popular enough) is I have custom scripts (called via the `alias` plugin) that alter my music library (not the beets database itself, but for instance my m3u playlists) and I needed to call `mpdupdate` and `subsonicupdate` afterwards.

Anyway the general idea is that I could trigger specific beets events when a custom script returns some exit status. What do you think?

P.S. `8` is a totally made up number. I know some exit codes are not to be used (for instance `1` and of course `0`), I had to use some number and I picked that one :-)